### PR TITLE
Add async Queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "nystudio107/craft-minify": "1.2.9",
         "nystudio107/craft-retour": "3.1.16",
         "nystudio107/craft-seomatic": "3.2.7",
+        "ostark/craft-async-queue": "2.0.0",
         "putyourlightson/craft-blitz": "2.0.8",
         "spicyweb/craft-fieldlabels": "1.1.2",
         "topshelfcraft/wordsmith": "3.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e55a397c113d7010361dc22610f00fe",
+    "content-hash": "6309f656e370e27a98c73411f6cddca6",
     "packages": [
         {
             "name": "albertofem/rsync-lib",
@@ -3867,6 +3867,55 @@
                 "issues": "https://nystudio107.com/plugins/seomatic/support"
             },
             "time": "2019-06-03T18:31:29+00:00"
+        },
+        {
+            "name": "ostark/craft-async-queue",
+            "version": "2.0.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ostark/craft-async-queue/zipball/3fce14ee8554d5a8fb66c5743d807026673d84de",
+                "reference": "3fce14ee8554d5a8fb66c5743d807026673d84de",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^3.0.0",
+                "symfony/process": "^4.2.0"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "AsyncQueue",
+                "handle": "async-queue",
+                "hasCpSettings": false,
+                "hasCpSection": false,
+                "changelogUrl": "https://raw.githubusercontent.com/ostark/craft-async-queue/master/CHANGELOG.md"
+            },
+            "autoload": {
+                "psr-4": {
+                    "ostark\\AsyncQueue\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Stark",
+                    "homepage": "https://www.fortrabbit.com"
+                }
+            ],
+            "description": "A queue handler that moves queue execution to a non-blocking background process",
+            "keywords": [
+                "cms",
+                "craft",
+                "craft-plugin",
+                "craftcms",
+                "queue"
+            ],
+            "support": {
+                "docs": "https://github.com/ostark/craft-async-queue/blob/master/README.md",
+                "issues": "https://github.com/ostark/craft-async-queue/issues"
+            },
+            "time": "2019-01-30T14:34:56+00:00"
         },
         {
             "name": "ostark/yii2-artisan-bridge",

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -277,8 +277,7 @@ commerce:
       templatePath: shop/_email.html
       attachPdf: false
       pdfTemplatePath: ''
-
-dateModified: 1561374760
+dateModified: 1561394678
 email:
   fromEmail: lindseyb@wearetelegraph.com
   fromName: '1517'
@@ -5880,6 +5879,10 @@ plugins:
     edition: standard
     enabled: true
     schemaVersion: 3.0.7
+  async-queue:
+    edition: standard
+    enabled: true
+    schemaVersion: 1.0.0
 routes:
   ab27c89e-4540-4090-90f5-59d726e23ab4:
     template: /events/
@@ -9573,3 +9576,23 @@ volumes:
       cfPrefix: ''
       autoFocalPoint: ''
     sortOrder: 4
+  0f79aa1a-f719-474a-ae2b-d2bf1a559917:
+    name: 'Images - Test'
+    handle: imagesTest
+    type: craft\awss3\Volume
+    hasUrls: true
+    url: 'https://s3.us-west-2.amazonaws.com/1517-assets-public/'
+    settings:
+      subfolder: images-test
+      keyId: $AWS_ACCESS_KEY_ID
+      secret: $AWS_SECRET_ACCESS_KEY
+      bucketSelectionMode: choose
+      bucket: 1517-assets-public
+      region: us-west-2
+      expires: ''
+      makeUploadsPublic: '1'
+      storageClass: ''
+      cfDistributionId: ''
+      cfPrefix: ''
+      autoFocalPoint: ''
+    sortOrder: 5


### PR DESCRIPTION
Adds test asset drive without optimizer field for seeing how well that performs with large dumps
Adds async queue plugin for helping with multiple authors working at once