### PR TITLE
fix hero images for categories

### DIFF
--- a/templates/_components/content-hero--podcast.twig
+++ b/templates/_components/content-hero--podcast.twig
@@ -57,7 +57,7 @@
 
         {% if cardImage|length %}
             <a href="{{ content.url }}" class="content-hero__media overflow-hidden">
-                <div class="inline-background -hover-scale h-full w-full" style="background-image: url('{{ cardImage.optimize.src(1276) }}')"></div>
+                <div class="inline-background -hover-scale h-full w-full" style="background-image: url('{{ cardImage.optimize.src() }}')"></div>
             </a>
         {% endif %}
     </div>

--- a/templates/_components/content-hero--video.twig
+++ b/templates/_components/content-hero--video.twig
@@ -52,7 +52,7 @@
         
         {# Media #}
         <a href="{{ content.url }}" class="content-hero__media overflow-hidden">
-            <div class="inline-background -hover-scale h-full w-full" style="background-image: url('{{ content.cardImage.one().optimize.src(1276) }}')"></div>
+            <div class="inline-background -hover-scale h-full w-full" style="background-image: url('{{ content.cardImage.one().optimize.src() }}')"></div>
         </a>
     </div>
 

--- a/web/mix-manifest.json
+++ b/web/mix-manifest.json
@@ -1,6 +1,5 @@
 {
-    "/assets/js/app.js": "/assets/js/app.js?id=034cd2a98e4f425b932c",
+    "/assets/js/app.js": "/assets/js/app.js?id=b04e17ed9938b7bb14f7",
     "/assets/css/shop.css": "/assets/css/shop.css?id=20db9612dfdc09e30dc9",
     "/assets/css/app.css": "/assets/css/app.css?id=2763b9553f4ce2d5eac7"
-    "/assets/js/app.js.map": "/assets/js/app.js.map?id=dea5d601fb58e11a73dc"
 }


### PR DESCRIPTION
@lindseybradford removing "1276" from `content.cardImage.one().optimize.src(1276)` fixes this issue: https://app.asana.com/0/1133743850720154/1136945140725065. I'm thinking it's b/c the cardImage is smaller than 1276 (user is prompted for 812x812). I'm worried that we'll lose quality if we remove "1276". Should we use another exact width instead? I noticed that "812" breaks the link as well but "576" works.